### PR TITLE
standardization and dockerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3-buster
+ENV PYTHONUNBUFFERED=1
+
+RUN apt update && apt install -y vim
+COPY requirements.txt *py /opt/app/
+RUN pip3 install -r /opt/app/requirements.txt
+CMD /opt/app/miner_exporter.py

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Details on the libraries:
 Please note this is only the exporter. Prometheus and Grafana server are required. They can be run on the same machine or external.
 
 ## Docker version
-Using the docker file, you can run this with Docker or docker-compose!
+Using the docker file, you can run this with Docker or docker-compose! Both of these expose Prometheus on 9152, feel free to choose your own port.
 
 ### Docker
 ```
 docker build . -tag me
-docker run -v /var/run/docker.sock:/var/run/docker.sock me
+docker run -p 9152:8000 -v /var/run/docker.sock:/var/run/docker.sock me
 ```
 
 ### Docker-Compose
@@ -41,4 +41,6 @@ services:
     container_name: miner_exporter
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+    - "9152:8000"
 ```

--- a/README.md
+++ b/README.md
@@ -6,10 +6,39 @@ This is only the exporter which still requires a prometheus server and grafana f
 
 ## Installation
 On the miner machine:
+
 install python3
-
-pip install prometheus_client [https://github.com/prometheus/client_python](https://github.com/prometheus/client_python)
-
-pip install psutil [https://github.com/giampaolo/psutil](https://github.com/giampaolo/psutil)
+```
+pip install prometheus_client psutil docker
+```
+Details on the libraries:
+* [client\_python](https://github.com/prometheus/client_python)
+* [psutil](https://github.com/giampaolo/psutil)
+* [docker](https://pypi.org/project/docker/)
 
 Please note this is only the exporter. Prometheus and Grafana server are required. They can be run on the same machine or external.
+
+## Docker version
+Using the docker file, you can run this with Docker or docker-compose!
+
+### Docker
+```
+docker build . -tag me
+docker run -v /var/run/docker.sock:/var/run/docker.sock me
+```
+
+### Docker-Compose
+Using your existing docker-compose file, add the section for the exporter (below). When you're done, run it with `docker-compose up -d --build`. That's it!
+```
+version: "3"
+services:
+  validator:
+    image: quay.io/team-helium/validator:latest-val-amd64
+    container_name: validator
+...
+  miner_exporter:
+    build: ./miner_exporter/
+    container_name: miner_exporter
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+```

--- a/miner_exporter.py
+++ b/miner_exporter.py
@@ -50,15 +50,16 @@ def stats():
   # need to fix this. hotspot name really should only be queried once
   out = docker_container.exec_run('miner info name')
   print(out.output)
-  hotspot_name=out.output.rstrip(b"\n")
+  hotspot_name = out.output.rstrip(b"\n")
+  hotspot_name_str = hotspot_name.decode('utf-8')
 
   # check if currently in consensus group
   out = docker_container.exec_run('miner info in_consensus')
   print(out.output)
   incon = 0
-  if out.output.rstrip(b"\n")=='true':
+  if out.output.rstrip(b"\n") == 'true':
     incon=1
-  INCON.labels(hotspot_name).set(incon)
+  INCON.labels(hotspot_name_str).set(incon)
 
   # collect current block age
   out = docker_container.exec_run('miner info block_age')
@@ -67,10 +68,10 @@ def stats():
   # parse the hbbft performance table for the penalty field
   out = docker_container.exec_run('miner hbbft perf')
   print(out.output)
-  results=out.output.split(b"\n")
+  results = out.output.split(b"\n")
   for line in results:
     if hotspot_name in line:
-      results=line.split()[12]
+      results = line.split()[12]
       PENALTY.labels('Penalty').set(results)
 
 

--- a/miner_exporter.py
+++ b/miner_exporter.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # external packages
 import prometheus_client
 import psutil
@@ -5,16 +7,13 @@ import psutil
 # internal packages
 import time
 import subprocess
+import docker
+import sys
+import os
 
 # time to sleep between scrapes
-UPDATE_PERIOD = 30
-
-# miner commands
-cmd_height = 'docker exec validator miner info height'.split()
-cmd_name = 'docker exec validator miner info name'.split()
-cmd_incon = 'docker exec validator miner info in_consensus'.split()
-cmd_blockage = 'docker exec validator miner info block_age'.split()
-cmd_hbbft_perf = 'docker exec validator miner hbbft perf'.split()
+UPDATE_PERIOD = int(os.environ.get('UPDATE_PERIOD', 30))
+VALIDATOR_CONTAINER_NAME = os.environ.get('VALIDATOR_CONTAINER_NAME', 'validator')
 
 # prometheus exporter types Gauge,Counter,Summary,Histogram,Info and Enum
 SYSTEM_USAGE = prometheus_client.Gauge('system_usage',
@@ -26,72 +25,60 @@ VAL = prometheus_client.Gauge('validator_height',
 
 INCON = prometheus_client.Gauge('validator_inconsensus',
                               'Is validator currently in consensus group',
-                              ['resource_type'])   
+                              ['resource_type'])
 BLOCKAGE = prometheus_client.Gauge('validator_block_age',
                               'Age of the current block',
-                             ['resource_type'])     
+                             ['resource_type'])
 PENALTY = prometheus_client.Gauge('validator_hbbft_penalty',
                               'HBBFT Penalty metrit from perf ',
-                             ['resource_type'])                                         
+                             ['resource_type'])
 
-if __name__ == '__main__':
-  prometheus_client.start_http_server(8000)
-  
-while True:
+def stats():
+  dc = docker.DockerClient()
+  docker_container = dc.containers.get(VALIDATOR_CONTAINER_NAME)
+
   # collect total cpu and memory usage. Might want to consider just the docker
   # container with something like cadvisor instead
   SYSTEM_USAGE.labels('CPU').set(psutil.cpu_percent())
   SYSTEM_USAGE.labels('Memory').set(psutil.virtual_memory()[2])
 
   # grab the local blockchain height
-  out=subprocess.run(cmd_height,
-                   #stdout=subprocess.DEVNULL,
-                   #stderr=subprocess.DEVNULL
-                   capture_output=True,
-                   universal_newlines=True,
-                   text=True) 
-  VAL.labels('Height').set(out.stdout.split()[1])
+  out = docker_container.exec_run('miner info height')
+  print(out.output)
+  VAL.labels('Height').set(out.output.split()[1])
 
   # need to fix this. hotspot name really should only be queried once
-  out=subprocess.run(cmd_name,
-                   capture_output=True,
-                   universal_newlines=True,
-                   text=True)
-  name=out.stdout.rstrip('\n')
+  out = docker_container.exec_run('miner info name')
+  print(out.output)
+  hotspot_name=out.output.rstrip(b"\n")
 
   # check if currently in consensus group
-  out=subprocess.run(cmd_incon,
-                   capture_output=True,
-                   universal_newlines=True,
-                   text=True)
-  if(out.stdout.rstrip('\n')=='true'):
+  out = docker_container.exec_run('miner info in_consensus')
+  print(out.output)
+  incon = 0
+  if out.output.rstrip(b"\n")=='true':
     incon=1
-  else:
-    incon=0  
-  INCON.labels(name).set(incon)
+  INCON.labels(hotspot_name).set(incon)
 
   # collect current block age
-  out=subprocess.run(cmd_blockage,
-                   capture_output=True,
-                   universal_newlines=True,
-                   text=True)
-  BLOCKAGE.labels('BlockAge').set(out.stdout)
+  out = docker_container.exec_run('miner info block_age')
+  BLOCKAGE.labels('BlockAge').set(out.output)
 
   # parse the hbbft performance table for the penalty field
-  out=subprocess.run(cmd_hbbft_perf,
-                   capture_output=True,
-                   universal_newlines=True,
-                   text=True)
-  results=out.stdout
-  results=results.split('\n')
-  try: 
-    for line in results:
-        if name in line:
-            results=line.split()[12]
-            PENALTY.labels('Penalty').set(results)     
-  except:
-    pass
+  out = docker_container.exec_run('miner hbbft perf')
+  print(out.output)
+  results=out.output.split(b"\n")
+  for line in results:
+    if hotspot_name in line:
+      results=line.split()[12]
+      PENALTY.labels('Penalty').set(results)
 
-  # sleep 30 seconds
-  time.sleep(UPDATE_PERIOD)
- 
+
+if __name__ == '__main__':
+  prometheus_client.start_http_server(8000)
+  while True:
+    stats()
+
+    # sleep 30 seconds
+    time.sleep(UPDATE_PERIOD)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+prometheus_client
+psutil
+docker


### PR DESCRIPTION
- add a Dockerfile! Setup with alpine was too fussy (eg psutils needed building), so I'm using debian as the base.
- add run examples for docker and docker-compose.
- use the `docker` lib rather than exec'ing `docker`. prettier, and fewer dependencies (especially when running in a container)
- remove the try/except block. Not sure what it would be catching.
- move the main code block into a function and then call it. Makes it more clear what is happening with
starting the server and running the code.
- add some tunable environment vars for the container name ('validator') and the sleep seconds.
- some Pythonic changes, the str-vs-bytes thing was dying in my installed versions of python.A
- remove some trailing whitespace