### PR TITLE
Find Docker Container Fallback

### DIFF
--- a/miner_exporter.py
+++ b/miner_exporter.py
@@ -118,7 +118,6 @@ def stats():
 
     # Try to find by specific name first
     docker_container = dc.containers.get(VALIDATOR_CONTAINER_NAME)
-    
   except docker.errors.NotFound as ex:
     # If find by specifc name fails, try to find by prefix
     containers = dc.containers.list()


### PR DESCRIPTION
When running the exporter in AWS ECS, there is no way to set the container name that will be used by docker. Instead the ECS Agent generates a name that is prefixed with the name of the ECS service. In order to be able to use the exporter in ECS, we need to be able to find the container by prefix if no container has the given specific name. 